### PR TITLE
Add repository assessment and clarify license

### DIFF
--- a/ASSESSMENT.md
+++ b/ASSESSMENT.md
@@ -1,0 +1,42 @@
+Short answer: **right now, usage looks minimal** and it’s unlikely to see casual adoption beyond people who want to reproduce the paper **unless** it’s packaged and documented more like a library.
+
+**Evidence from the repo (today):**
+
+* **0 stars, 0 forks, 0 issues, 0 pull requests** → little external engagement so far. ([GitHub][1])
+* **MIT license shown** on GitHub **but** the README also says “This code is released for academic use only” → mixed licensing signals that can deter users. ([GitHub][1])
+* **No releases or packages published**; no PyPI install. ([GitHub][1])
+* **Community/profile** items are sparse (no contributing guide, code of conduct, issue templates, security policy). ([GitHub][2])
+* Usage is oriented to **one-off reproduction**: “run `python experiments.py`” to regenerate paper results; it’s not presented as a drop-in optimizer for common ML workflows. ([GitHub][1])
+
+### Who would use it (as-is)?
+
+* **Optimization/ML theory folks** reproducing plots and constants from the paper or studying the proofs.
+* **Students** in a theory/optimization course needing a reference implementation tied to the manuscript.
+
+### Who probably won’t (as-is)?
+
+* **Practitioners** training models in PyTorch/TF/JAX who expect a plug-and-play `Optimizer` class, tutorials, Colab notebooks, and benchmarks against SGD/Adam on standard tasks (CIFAR/ImageNet/NLP).
+
+### Main adoption blockers
+
+1. **Packaging gap**: no pip/conda install; no `Optimizer` interface for PyTorch/Keras/JAX. ([GitHub][1])
+2. **Docs/tutorials lacking**: README is minimal; no quickstart/Colab; no API docs. ([GitHub][1])
+3. **Licensing ambiguity**: MIT on GitHub but README text says “academic use only.” Clarify to avoid legal uncertainty. ([GitHub][1])
+4. **Community signals**: no issues/PRs/templates; no CI; no releases, which reduces trust for production use. ([GitHub][1])
+
+### What would make people use it (prioritized, concrete)
+
+1. **Ship a PyPI package** (`pip install psd-optimizer`) with a **PyTorch `torch.optim.Optimizer`** wrapper and examples (MNIST/CIFAR).
+2. **Add a Colab notebook**: “10-minute PSD quickstart” with reproducible seeds and plots.
+3. **Clarify license**: ensure README matches the MIT file (or change the LICENSE if “academic only” is intended). ([GitHub][1])
+4. **Publish a tagged release** (e.g., `v0.1.0`) and add **GitHub Actions CI** to run tests and style checks on pushes/PRs. ([GitHub][1])
+5. **Benchmarks**: wall-clock comparisons vs SGD/Adam/PGD on at least two public datasets; report accuracy, time, and memory.
+6. **Docs site** (e.g., MkDocs) with API reference, “Theory ↔ Practice” mapping (how to set $\varepsilon,\delta,T,r$), and troubleshooting.
+7. **Community hygiene**: `CONTRIBUTING.md`, issue/PR templates, Code of Conduct, Security policy — these raise confidence and reduce friction. ([GitHub][2])
+
+### Verdict
+
+* **Current likelihood of use:** *Low outside research reproduction*. The repo is brand-new, minimally packaged, and not yet discoverable or turnkey for practitioners. With packaging, clearer licensing, tutorials, and benchmarks, it could find a niche among optimization researchers and curious practitioners. ([GitHub][1])
+
+[1]: https://github.com/farukalpay/PSD "GitHub - farukalpay/PSD: Perturbed Saddle-escape Descent (PSD): a first-order optimizer that escapes strict saddle points in nonconvex problems."
+[2]: https://github.com/farukalpay/PSD/community "Community Standards · GitHub"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,6 @@ psd_project/
 
 ## Licence
 
-This code is released for academic use only.  See the accompanying
-manuscript for a complete description of the algorithm and its
-theoretical guarantees.
+This project is licensed under the [MIT License](LICENSE).  See the
+accompanying manuscript for a complete description of the algorithm and
+its theoretical guarantees.


### PR DESCRIPTION
## Summary
- add detailed repository assessment outlining current adoption and recommendations
- clarify README licensing to reference MIT License

## Testing
- `python -m py_compile algorithms.py functions.py experiments.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8853cacb88323802923d71f1b19e5