### PR TITLE
Add PyTorch PSD optimizer package with MNIST/CIFAR examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ points in non‑convex optimisation problems.  This repository includes:
   lengths, per‑episode decreases, convergence iterations and noise
   robustness.
 
+## PyTorch Optimizer
+
+The repository now also exposes a small PyTorch package providing a
+``torch.optim.Optimizer`` implementation of PSD.  The package can be
+installed from PyPI:
+
+```bash
+pip install psd-optimizer
+```
+
+Example training scripts for MNIST and CIFAR‑10 using this optimizer are
+available in the ``examples/`` directory.
+
 ## Running the Experiments
 
 All experiments can be reproduced by executing the following command from

--- a/examples/cifar10_example.py
+++ b/examples/cifar10_example.py
@@ -1,0 +1,43 @@
+"""Train a simple CIFAR-10 classifier using the PSD optimizer."""
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+from torchvision import datasets, transforms
+
+from psd_optimizer import PSDOptimizer
+
+
+def main() -> None:
+    transform = transforms.Compose(
+        [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]
+    )
+    train = datasets.CIFAR10(root="./data", train=True, download=True, transform=transform)
+    loader = DataLoader(train, batch_size=64, shuffle=True)
+
+    model = nn.Sequential(
+        nn.Conv2d(3, 32, 3, padding=1),
+        nn.ReLU(),
+        nn.AdaptiveAvgPool2d((1, 1)),
+        nn.Flatten(),
+        nn.Linear(32, 10),
+    )
+    loss_fn = nn.CrossEntropyLoss()
+    optimizer = PSDOptimizer(model.parameters(), lr=0.01, epsilon=1e-3, r=1e-2, T=5)
+
+    model.train()
+    for epoch in range(1):
+        for batch in loader:
+            def closure():
+                optimizer.zero_grad()
+                x, y = batch
+                output = model(x)
+                loss = loss_fn(output, y)
+                loss.backward()
+                return loss
+            optimizer.step(closure)
+        print(f"Epoch {epoch+1} complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mnist_example.py
+++ b/examples/mnist_example.py
@@ -1,0 +1,35 @@
+"""Train a simple MNIST classifier using the PSD optimizer."""
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+from torchvision import datasets, transforms
+
+from psd_optimizer import PSDOptimizer
+
+
+def main() -> None:
+    transform = transforms.ToTensor()
+    train = datasets.MNIST(root="./data", train=True, download=True, transform=transform)
+    loader = DataLoader(train, batch_size=64, shuffle=True)
+
+    model = nn.Sequential(nn.Flatten(), nn.Linear(28 * 28, 10))
+    loss_fn = nn.CrossEntropyLoss()
+    optimizer = PSDOptimizer(model.parameters(), lr=0.1, epsilon=1e-3, r=1e-2, T=5)
+
+    model.train()
+    for epoch in range(1):
+        for batch in loader:
+            def closure():
+                optimizer.zero_grad()
+                x, y = batch
+                output = model(x)
+                loss = loss_fn(output, y)
+                loss.backward()
+                return loss
+            optimizer.step(closure)
+        print(f"Epoch {epoch+1} complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/psd_optimizer/__init__.py
+++ b/psd_optimizer/__init__.py
@@ -1,0 +1,7 @@
+"""PyTorch optimizer implementing Perturbed Saddle-point Descent (PSD)."""
+
+from .optimizer import PSDOptimizer
+
+__all__ = ["PSDOptimizer"]
+
+__version__ = "0.1.0"

--- a/psd_optimizer/optimizer.py
+++ b/psd_optimizer/optimizer.py
@@ -1,0 +1,75 @@
+import math
+from typing import Iterable, Optional, Callable
+
+import torch
+from torch.optim.optimizer import Optimizer
+
+
+class PSDOptimizer(Optimizer):
+    """Perturbed Saddle-point Descent (PSD) optimizer.
+
+    This is a simple PyTorch implementation of the PSD algorithm described in
+    the accompanying paper.  The optimizer behaves like gradient descent when
+    the gradient norm is large.  When the norm falls below ``epsilon`` it
+    injects random noise of radius ``r`` and performs ``T`` additional gradient
+    steps in an attempt to escape saddle points.
+
+    The implementation requires a ``closure`` function in ``step`` similar to
+    :class:`torch.optim.LBFGS` so that gradients can be recomputed multiple
+    times during the escape episode.
+    """
+
+    def __init__(
+        self,
+        params: Iterable[torch.nn.Parameter],
+        lr: float = 1e-3,
+        epsilon: float = 1e-3,
+        r: float = 1e-3,
+        T: int = 10,
+    ) -> None:
+        if lr <= 0:
+            raise ValueError("Invalid learning rate")
+        defaults = dict(lr=lr, epsilon=epsilon, r=r, T=T)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self, closure: Optional[Callable[[], float]] = None):
+        """Perform a single optimization step.
+
+        Parameters
+        ----------
+        closure : callable, optional
+            A closure that re-evaluates the model and returns the loss.  This is
+            required because the PSD escape episode may need to re-compute the
+            gradients multiple times.
+        """
+        if closure is None:
+            raise RuntimeError("PSDOptimizer requires a closure to evaluate the model")
+
+        loss = closure()
+        params = [p for group in self.param_groups for p in group['params'] if p.grad is not None]
+        if not params:
+            return loss
+
+        grad_norm = torch.sqrt(sum(torch.sum(p.grad.detach() ** 2) for p in params))
+        eps = self.param_groups[0]['epsilon']
+        lr = self.param_groups[0]['lr']
+
+        if grad_norm > eps:
+            for p in params:
+                p.add_(p.grad, alpha=-lr)
+            return loss
+
+        # Escape episode
+        r = self.param_groups[0]['r']
+        T = self.param_groups[0]['T']
+        for p in params:
+            noise = torch.randn_like(p) * r
+            p.add_(noise)
+
+        for _ in range(T):
+            loss = closure()
+            for p in params:
+                if p.grad is not None:
+                    p.add_(p.grad, alpha=-lr)
+        return loss

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "psd-optimizer"
+version = "0.1.0"
+description = "Perturbed Saddle-point Descent optimizer for PyTorch"
+authors = [{name = "PSD Authors"}]
+license = {text = "MIT"}
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "torch",
+    "torchvision",
+]
+
+[project.urls]
+Homepage = "https://github.com/farukalpay/PSD"
+
+[tool.setuptools.packages.find]
+include = ["psd_optimizer"]


### PR DESCRIPTION
## Summary
- add `psd_optimizer` package exposing a `torch.optim.Optimizer` PSD implementation
- provide MNIST and CIFAR-10 usage examples
- configure packaging metadata and document PyTorch optimizer in README
- point package homepage to the project's GitHub repository

## Testing
- `python -m py_compile psd_optimizer/optimizer.py psd_optimizer/__init__.py examples/mnist_example.py examples/cifar10_example.py`
- `python -m pip install . --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68a88a9c38488323a63b574e469ba3f1