### PR TITLE
Add community guidelines and move assessment doc

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[Bug]"
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+ - OS: [e.g. Ubuntu 20.04]
+ - Python version [e.g. 3.10]
+ - Version [e.g. commit hash or release]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feature]"
+labels: enhancement
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+# Summary
+
+Please provide a summary of the changes and the related issue.
+
+## Checklist
+
+- [ ] Tests pass (`pytest`)
+- [ ] Documentation updated if needed
+- [ ] Code follows the style guidelines
+
+## Related Issues
+
+List any related issues or pull requests.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,50 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders at [alpay@lightcap.ai](mailto:alpay@lightcap.ai).
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1.
+
+[homepage]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing to PSD
+
+Thank you for considering contributing to PSD. We welcome bug reports, feature requests, and pull requests.
+
+## Reporting Issues
+
+Use the issue templates in [\.github/ISSUE_TEMPLATE](.github/ISSUE_TEMPLATE) when opening issues. Clearly describe the problem and include steps to reproduce when relevant.
+
+## Development Setup
+
+1. Create a virtual environment and install the project in editable mode:
+   ```bash
+   pip install -e .
+   ```
+2. Run the test suite to ensure everything works:
+   ```bash
+   pytest
+   ```
+
+## Submitting Changes
+
+1. Fork the repository and create a feature branch.
+2. Make your changes and run `pytest`.
+3. Commit your work with clear messages.
+4. Open a pull request using the provided template.
+
+By participating in this project, you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ psd_project/
 └── results/          # CSV summaries of other experimental metrics
 ```
 
+## Contributing
+
+We welcome contributions of all kinds. To get started, please read
+[CONTRIBUTING.md](CONTRIBUTING.md). By participating in this project, you
+agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md). Security issues
+should be reported privately as described in
+[SECURITY.md](SECURITY.md). For general questions, contact
+[alpay@lightcap.ai](mailto:alpay@lightcap.ai).
+
 ## Licence
 
 This project is licensed under the [MIT License](LICENSE).  See the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security issue, please report it by emailing [alpay@lightcap.ai](mailto:alpay@lightcap.ai).
+Please do not disclose security-related issues publicly until they have been
+addressed.
+
+We will acknowledge your email and provide updates on the resolution status as
+quickly as possible.

--- a/docs/ASSESSMENT.md
+++ b/docs/ASSESSMENT.md
@@ -1,3 +1,7 @@
+# Project Assessment
+
+> This document captures an automated assessment of the repository's initial community and packaging status. It is retained for educational purposes and is not part of the contribution guidelines.
+
 Short answer: **right now, usage looks minimal** and it’s unlikely to see casual adoption beyond people who want to reproduce the paper **unless** it’s packaged and documented more like a library.
 
 **Evidence from the repo (today):**


### PR DESCRIPTION
## Summary
- add CONTRIBUTING guide, code of conduct, security policy, and issue/PR templates
- move assessment into docs for educational reference and link contribution info from README
- replace placeholder emails with project contact and note address in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a88cc175f08323a3005391357f312d