### PR TITLE
refactor: add config object and feature flags

### DIFF
--- a/src/psd/__init__.py
+++ b/src/psd/__init__.py
@@ -3,7 +3,7 @@
 from . import algorithms, functions
 from .config import PSDConfig
 from .feature_flags import FLAGS, FeatureFlags, disable, enable
-from .graph import find_optimal_path
+from .graph import GraphConfig, find_optimal_path
 
 try:  # Optional framework-specific optimisers
     from .framework_optimizers import PSDTensorFlow, PSDTorch
@@ -15,6 +15,7 @@ __all__ = [
     "algorithms",
     "functions",
     "find_optimal_path",
+    "GraphConfig",
     "PSDConfig",
     "FeatureFlags",
     "FLAGS",

--- a/src/psd/feature_flags.py
+++ b/src/psd/feature_flags.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 
 
@@ -9,8 +10,22 @@ class FeatureFlags:
 
     new_escape_condition: bool = False
 
+    @classmethod
+    def from_env(cls) -> "FeatureFlags":
+        """Create flags based on environment variables."""
 
-FLAGS = FeatureFlags()
+        def _env_true(name: str, default: bool = False) -> bool:
+            return os.getenv(name, str(default)).lower() in {
+                "1",
+                "true",
+                "yes",
+                "on",
+            }
+
+        return cls(new_escape_condition=_env_true("PSD_NEW_ESCAPE_CONDITION"))
+
+
+FLAGS = FeatureFlags.from_env()
 
 
 def enable(flag: str) -> None:

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -1,0 +1,41 @@
+import importlib
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from psd import algorithms
+from psd.config import PSDConfig
+
+
+def test_env_var_enables_flag(monkeypatch):
+    from psd.feature_flags import FeatureFlags
+
+    monkeypatch.setenv("PSD_NEW_ESCAPE_CONDITION", "1")
+    flags = FeatureFlags.from_env()
+    assert flags.new_escape_condition is True
+
+
+def test_new_escape_condition_changes_step_size():
+    import psd.feature_flags as ff
+
+    def grad(x):
+        return x
+
+    def hess(x):
+        return np.eye(len(x))
+
+    x0 = np.array([1.0])
+    cfg = PSDConfig(epsilon=1e-12, ell=1.0, rho=1.0, max_iter=1)
+
+    ff.disable("new_escape_condition")
+    x, _ = algorithms.psd(x0, grad, hess, 1e-12, 1.0, 1.0, config=cfg)
+    assert np.allclose(x, np.array([0.5]))
+
+    ff.enable("new_escape_condition")
+    x, _ = algorithms.psd(x0, grad, hess, 1e-12, 1.0, 1.0, config=cfg)
+    assert np.allclose(x, np.array([0.0]))
+    ff.disable("new_escape_condition")

--- a/tests/test_find_optimal_path.py
+++ b/tests/test_find_optimal_path.py
@@ -5,7 +5,7 @@ from pathlib import Path
 # Ensure the src directory is on the path for imports
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
-from psd import find_optimal_path  # noqa: E402
+from psd import GraphConfig, find_optimal_path  # noqa: E402
 
 
 class TestFindOptimalPath(unittest.TestCase):
@@ -52,6 +52,16 @@ class TestFindOptimalPath(unittest.TestCase):
         }
         with self.assertRaises(OverflowError):
             find_optimal_path(graph, "A", "C")
+
+    def test_custom_config_overrides_max_weight(self):
+        graph = {"A": {"B": 1e6}, "B": {"C": 1e6}, "C": {}}
+        cfg = GraphConfig(max_path_weight=1e6)
+        with self.assertRaises(OverflowError):
+            find_optimal_path(graph, "A", "C", config=cfg)
+
+    def test_graph_config_validation(self):
+        with self.assertRaises(ValueError):
+            GraphConfig(max_path_weight=-1.0)
 
     def test_large_graph(self):
         # Construct a linear DAG A0 -> A1 -> ... -> A999 -> A1000


### PR DESCRIPTION
## Summary
- replace graph module constant with validated `GraphConfig`
- load feature flags from environment and use them in algorithms
- cover config and feature flags with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa0ddbb6ac8323bde4531dd9b71f52