### PR TITLE
ci: add parallel lint, typecheck and test workflow with coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,14 @@ jobs:
             ${{ runner.os }}-pip-
       - run: pip install -e .[dev] pytest-github-actions-annotate-failures
       - run: pytest tests --ignore=tests/test_algorithms_property.py --maxfail=1 --cov=psd --cov-report=term
-      - run: mv .coverage .coverage.unit
+      - name: Prepare coverage artifact
+        if: always()
+        run: |
+          if [ -f .coverage ]; then
+            mv .coverage .coverage.unit
+          else
+            touch .coverage.unit
+          fi
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -77,7 +84,14 @@ jobs:
             ${{ runner.os }}-pip-
       - run: pip install -e .[dev] pytest-github-actions-annotate-failures
       - run: pytest tests/test_algorithms_property.py --maxfail=1 --cov=psd --cov-report=term
-      - run: mv .coverage .coverage.property
+      - name: Prepare coverage artifact
+        if: always()
+        run: |
+          if [ -f .coverage ]; then
+            mv .coverage .coverage.property
+          else
+            touch .coverage.property
+          fi
       - uses: actions/upload-artifact@v4
         if: always()
         with:


### PR DESCRIPTION
## Summary
- run lint and typecheck as separate jobs with GitHub annotations
- split unit and property tests with fail-fast and annotate failures
- combine and upload coverage results, ensuring artifacts upload and download correctly
- drop unsupported mypy error format flag

## Testing
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68aa3bfd59f48323b5c4e923f0e9287b