### PR TITLE
Add golden file test for optimizer state serialization

### DIFF
--- a/tests/golden/psd_torch_state.json
+++ b/tests/golden/psd_torch_state.json
@@ -1,0 +1,25 @@
+{
+  "param_groups": [
+    {
+      "g_thres": 0.001,
+      "lr": 0.1,
+      "max_grad_norm": 1.0,
+      "params": [
+        0,
+        1
+      ],
+      "r": 0.001,
+      "t_thres": 10
+    }
+  ],
+  "state": {
+    "0": {
+      "t": 1,
+      "t_noise": -Infinity
+    },
+    "1": {
+      "t": 1,
+      "t_noise": -Infinity
+    }
+  }
+}

--- a/tests/test_optimizer_serialization.py
+++ b/tests/test_optimizer_serialization.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+
+import torch
+
+from psd.framework_optimizers import PSDTorch
+
+
+def _compute_state_dict() -> dict:
+    model = torch.nn.Linear(1, 1)
+    model.weight.data.fill_(1.0)
+    model.bias.data.fill_(0.0)
+    opt = PSDTorch(model.parameters(), lr=0.1)
+
+    x = torch.tensor([[1.0]])
+    y = torch.tensor([[2.0]])
+    criterion = torch.nn.MSELoss()
+
+    def closure() -> torch.Tensor:
+        opt.zero_grad()
+        out = model(x)
+        loss = criterion(out, y)
+        loss.backward()
+        return loss
+
+    opt.step(closure)
+    return opt.state_dict()
+
+
+def test_psd_torch_state_dict_matches_golden() -> None:
+    state = _compute_state_dict()
+    generated = json.dumps(state, sort_keys=True, indent=2, allow_nan=True)
+    golden_path = Path(__file__).parent / "golden" / "psd_torch_state.json"
+    expected = golden_path.read_text().strip()
+    assert generated == expected


### PR DESCRIPTION
## Summary
- add regression test capturing PSDTorch state after an optimization step
- store optimizer state in a golden file to guard against serialization regressions

## Testing
- `PYTHONPATH=src pytest`
- `pre-commit run --files tests/test_optimizer_serialization.py tests/golden/psd_torch_state.json`


------
https://chatgpt.com/codex/tasks/task_e_68aa8eaff4b883239f431fb05b3b36be