### PR TITLE
Add golden file test for optimizer state serialization

### DIFF
--- a/src/psd/algorithms.py
+++ b/src/psd/algorithms.py
@@ -71,7 +71,7 @@ def psd(
     random_state: np.random.Generator | None = None,
     config: PSDConfig | None = None,
 ) -> tuple[np.ndarray, int]:
-    """Perturbed Saddle‑escape Descent (PSD).
+    r"""Perturbed Saddle‑escape Descent (PSD).
 
     This implementation follows the algorithm described in the manuscript
     and uses explicit constants.  It is designed for pedagogical use and

--- a/src/psd/functions.py
+++ b/src/psd/functions.py
@@ -11,11 +11,12 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import TypeAlias
 
 import numpy as np
 from numpy.typing import NDArray
 
-Array = NDArray[np.float64]
+Array: TypeAlias = NDArray[np.float64]
 
 
 @dataclass(frozen=True)
@@ -33,7 +34,7 @@ class TestFunction:
 
 
 def separable_quartic(x: Array) -> float:
-    """Compute the value of the separable quartic function.
+    r"""Compute the value of the separable quartic function.
 
     The separable quartic is defined as
 
@@ -58,7 +59,7 @@ def separable_quartic(x: Array) -> float:
 
 
 def separable_quartic_grad(x: Array) -> Array:
-    """Gradient of the separable quartic function.
+    r"""Gradient of the separable quartic function.
 
     Gradient is given by :math:`\grad f(x) = 4 x^3 - 2 x`.
 
@@ -100,7 +101,7 @@ def separable_quartic_hess(x: Array) -> Array:
 
 
 def coupled_quartic(x: Array) -> float:
-    """Compute the value of the coupled quartic function.
+    r"""Compute the value of the coupled quartic function.
 
     This function couples the separable quartic with a weak quadratic term:
 
@@ -176,7 +177,7 @@ def coupled_quartic_hess(x: Array) -> Array:
 
 
 def rosenbrock(x: Array) -> float:
-    """Compute the Rosenbrock function in d dimensions.
+    r"""Compute the Rosenbrock function in d dimensions.
 
     The standard Rosenbrock function in d dimensions is defined as
 
@@ -253,7 +254,7 @@ def rosenbrock_hess(x: Array) -> Array:
 
 
 def random_quadratic(d: int, seed: int | None = None) -> tuple[Array, Array]:
-    """Generate a random quadratic function with controlled spectrum.
+    r"""Generate a random quadratic function with controlled spectrum.
 
     The function has the form
 

--- a/tests/golden/psd_torch_state.json
+++ b/tests/golden/psd_torch_state.json
@@ -1,0 +1,25 @@
+{
+  "param_groups": [
+    {
+      "g_thres": 0.001,
+      "lr": 0.1,
+      "max_grad_norm": 1.0,
+      "params": [
+        0,
+        1
+      ],
+      "r": 0.001,
+      "t_thres": 10
+    }
+  ],
+  "state": {
+    "0": {
+      "t": 1,
+      "t_noise": -Infinity
+    },
+    "1": {
+      "t": 1,
+      "t_noise": -Infinity
+    }
+  }
+}

--- a/tests/test_optimizer_serialization.py
+++ b/tests/test_optimizer_serialization.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+
+import torch
+
+from psd.framework_optimizers import PSDTorch
+
+
+def _compute_state_dict() -> dict:
+    model = torch.nn.Linear(1, 1)
+    model.weight.data.fill_(1.0)
+    model.bias.data.fill_(0.0)
+    opt = PSDTorch(model.parameters(), lr=0.1)
+
+    x = torch.tensor([[1.0]])
+    y = torch.tensor([[2.0]])
+    criterion = torch.nn.MSELoss()
+
+    def closure() -> torch.Tensor:
+        opt.zero_grad()
+        out = model(x)
+        loss = criterion(out, y)
+        loss.backward()
+        return loss
+
+    opt.step(closure)
+    return opt.state_dict()
+
+
+def test_psd_torch_state_dict_matches_golden() -> None:
+    state = _compute_state_dict()
+    generated = json.dumps(state, sort_keys=True, indent=2, allow_nan=True)
+    golden_path = Path(__file__).parent / "golden" / "psd_torch_state.json"
+    expected = golden_path.read_text().strip()
+    assert generated == expected


### PR DESCRIPTION
## Summary
- add regression test capturing PSDTorch state after an optimization step
- store optimizer state in a golden file to guard against serialization regressions
- define TensorFlow optimizer only when TensorFlow is installed and silence docstring escape warnings

## Testing
- `pre-commit run --files src/psd/framework_optimizers.py src/psd/algorithms.py src/psd/functions.py tests/test_optimizer_serialization.py tests/golden/psd_torch_state.json`
- `PYTHONPATH=src pytest --ignore=tests/test_algorithms_property.py --maxfail=1 --cov=psd --cov-report=term`


------
https://chatgpt.com/codex/tasks/task_e_68aa8eaff4b883239f431fb05b3b36be